### PR TITLE
16 behaviour when round resolving

### DIFF
--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
@@ -20,7 +20,7 @@
         <div leaflet id="guessingMap" class="map" [leafletOptions]="guessingMapOptions"
             (leafletClick)="onGuessingMapClicked($event)" [leafletMaxBounds]="guessingMapMaxBounds"
             [leafletFitBounds]="guessingMapFitBounds">
-            <div *ngIf="showGuessingMarker" [leafletLayer]="guessingMarker"></div>
+            <div *ngIf="guessingMarker != undefined" [leafletLayer]="guessingMarker"></div>
             <div *ngIf="gameStatus=='RESULT'" [leafletLayer]="materializedGuessingMapTile"></div>
         </div>
     </div>

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
@@ -21,6 +21,7 @@
             (leafletClick)="onGuessingMapClicked($event)" [leafletMaxBounds]="guessingMapMaxBounds"
             [leafletFitBounds]="guessingMapFitBounds">
             <div *ngIf="guessingMarker != undefined" [leafletLayer]="guessingMarker"></div>
+            <div *ngIf="resultLine != undefined" [leafletLayer]="resultLine"></div>
             <div *ngIf="gameStatus=='RESULT'" [leafletLayer]="materializedGuessingMapTile"></div>
         </div>
     </div>

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
@@ -20,7 +20,7 @@
         <div leaflet id="guessingMap" class="map" [leafletOptions]="guessingMapOptions"
             (leafletClick)="onGuessingMapClicked($event)" [leafletMaxBounds]="guessingMapMaxBounds"
             [leafletFitBounds]="guessingMapFitBounds">
-            <div [leafletLayer]="guessingMarker"></div>
+            <div *ngIf="showGuessingMarker" [leafletLayer]="guessingMarker"></div>
             <div *ngIf="gameStatus=='RESULT'" [leafletLayer]="materializedGuessingMapTile"></div>
         </div>
     </div>

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
@@ -9,14 +9,14 @@
         </p>
     </div>
 
-    <div class="mapContainer" id="satelliteMapContainer">
+    <div *ngIf="['PLAYING','RESULT'].includes(gameStatus)" class="mapContainer" id="satelliteMapContainer">
         <div leaflet id="satelliteMap" class="map" [leafletOptions]="satelliteMapOptions"
             [(leafletCenter)]="satelliteMapCenter" [leafletMaxBounds]="satelliteMaxBounds">
             <div [leafletLayer]="materializedSatelliteMapTile"></div>
         </div>
     </div>
 
-    <div class="mapContainer" id="guessingMapContainer">
+    <div *ngIf="['PLAYING','RESULT'].includes(gameStatus)" class="mapContainer" id="guessingMapContainer">
         <div leaflet id="guessingMap" class="map" [leafletOptions]="guessingMapOptions"
             (leafletClick)="onGuessingMapClicked($event)" [leafletMaxBounds]="guessingMapMaxBounds"
             [leafletFitBounds]="guessingMapFitBounds">
@@ -32,8 +32,14 @@
             (click)="onRespawnClicked()">Respawn</button>
         <button *ngIf="gameStatus=='PLAYING'" id="guessButton" class="button" role="button"
             (click)="onGuessClicked()">Guess</button>
-        <button *ngIf="gameStatus=='RESULT'" id="launchNextRoundButton" class="button" role="button"
-            (click)="onLaunchNextRoundClicked()">Launch next round</button>
+        <button *ngIf="gameStatus=='RESULT' && (!currentRoundIsTheLast)" id="launchNextRoundButton" class="button"
+            role="button" (click)="onLaunchNextRoundClicked()">
+            Launch next round
+        </button>
+        <button *ngIf="gameStatus=='RESULT' && (currentRoundIsTheLast)" id="launchOverviewRoundButton" class="button"
+            role="button" (click)="onEndGame()">
+            End game
+        </button>
         <button *ngIf="gameStatus=='ENDED'" id="playAgainButton" class="button" role="button"
             (click)="onPlayAgainClicked()">Play again</button>
     </div>

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.html
@@ -12,7 +12,7 @@
     <div class="mapContainer" id="satelliteMapContainer">
         <div leaflet id="satelliteMap" class="map" [leafletOptions]="satelliteMapOptions"
             [(leafletCenter)]="satelliteMapCenter" [leafletMaxBounds]="satelliteMaxBounds">
-            <div [leafletLayer]="materializedBounds"></div>
+            <div [leafletLayer]="materializedSatelliteMapTile"></div>
         </div>
     </div>
 
@@ -21,6 +21,7 @@
             (leafletClick)="onGuessingMapClicked($event)" [leafletMaxBounds]="guessingMapMaxBounds"
             [leafletFitBounds]="guessingMapFitBounds">
             <div [leafletLayer]="guessingMarker"></div>
+            <div *ngIf="gameStatus=='RESULT'" [leafletLayer]="materializedGuessingMapTile"></div>
         </div>
     </div>
 

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -42,6 +42,12 @@ const FOUNDED_TILE_RECTANGLE_STYLE: PathOptions = {
   fillColor: "#a3ee95",
   opacity: 0.75
 }
+const NOT_FOUNDED_TILE_RECTANGLE_STYLE: PathOptions = {
+  color: "#f88958",
+  fill: true,
+  fillColor: "#f88958",
+  opacity: 0.75
+}
 
 interface Round {
   latitude: number,
@@ -194,6 +200,9 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     if (guessedIntoTheTile) {
       this.materializedGuessingMapTile.setStyle(FOUNDED_TILE_RECTANGLE_STYLE)
       this.materializedSatelliteMapTile.setStyle(FOUNDED_TILE_RECTANGLE_STYLE)
+    } else {
+      this.materializedGuessingMapTile.setStyle(NOT_FOUNDED_TILE_RECTANGLE_STYLE)
+      this.materializedSatelliteMapTile.setStyle(NOT_FOUNDED_TILE_RECTANGLE_STYLE)
     }
   }
 

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -279,7 +279,7 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     const timeScore = this.secretScoreFunction(
       MILLISECONDS_IN_A_ROUND - remainingTimeInMs,
       MAX_SCORE_FOR_TIME,
-      MIN_TIME_MS,
+      MILLISECONDS_IN_A_ROUND - MIN_TIME_MS,
       MILLISECONDS_IN_A_ROUND * COEF_TIME,
     )
 

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -253,10 +253,6 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
 
     // diplaying result
     this.displayResult(score, distInMeters, guessedIntoTheTile)
-
-    if (this.currentRoundIndex >= this.rounds.length - 1) {
-      this.gameStatus = GameStatus.ENDED
-    }
   }
 
   ///////////////////////////////////////////////////////////////////////
@@ -349,6 +345,10 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     return this.rounds[this.currentRoundIndex]
   }
 
+  get currentRoundIsTheLast(): boolean {
+    return this.currentRoundIndex == NUMBER_OF_ROUNDS - 1
+  }
+
   ///////////////////////////////////////////////////////////////////////
   /////// LISTENERS
   ///////////////////////////////////////////////////////////////////////
@@ -381,6 +381,11 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
 
   protected onRespawnClicked() {
     this.satelliteMapCenter = this.coordinatesToGuess.clone()
+  }
+
+  protected onEndGame() {
+    this.description = "Congratulation !"
+    this.gameStatus = GameStatus.ENDED
   }
 
 }

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -200,13 +200,6 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     this.roundScore = score
     this.gameScore += score
 
-    // displaying description
-    if (dist == undefined) {
-      this.description = `You forgot to click on the map ! You were in ${currentRound.name}`
-    } else {
-      this.description = `You were ${Math.round(dist / 1000)} km from ${currentRound.name}`
-    }
-
     if (guessedIntoTheTile) {
       // if the player guessed into the tile, display materialized tiles in green
       this.materializedGuessingMapTile.setStyle(FOUNDED_TILE_RECTANGLE_STYLE)
@@ -214,20 +207,33 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
 
       // centering map on tile
       this.guessingMapFitBounds = this.materializedGuessingMapTile.getBounds()
+
+      // displaying tailored description
+      this.description = `Congratulations, you found ${currentRound.name}`
     } else {
       // otherwise display materialized tiles in orange
       this.materializedGuessingMapTile.setStyle(NOT_FOUNDED_TILE_RECTANGLE_STYLE)
       this.materializedSatelliteMapTile.setStyle(NOT_FOUNDED_TILE_RECTANGLE_STYLE)
 
       if (this.guessingMarker != undefined) {
+        if (dist != undefined) {
+          // displaying tailored description
+          this.description = `You were ${Math.round(dist / 1000)} km from ${currentRound.name}`
+        }
+
         // adding a line between the guessing marker and the tile
         this.resultLine = new Polyline(
           [this.coordinatesToGuess, this.guessingMarker.getLatLng()],
           RESULT_LINE_OPTIONS
         )
+
         // centering the map to the line
         this.guessingMapFitBounds = this.resultLine.getBounds()
+
       } else {
+        // displaying tailored description
+        this.description = `You forgot to click on the map ! You were in ${currentRound.name}`
+
         // centering map on tile
         this.guessingMapFitBounds = this.materializedGuessingMapTile.getBounds()
       }

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -19,7 +19,7 @@ const MILLISECONDS_IN_A_ROUND = 1000 * 60 * 3
 const MAX_SCORE_FOR_DIST = 800 // max score reachable 
 const COEF_DIST = 0.8 // this means that player will have 0 points for dist if the guess is more than 0.8 * max bounds 
 const MAX_SCORE_FOR_TIME = 200
-const MIN_TIME_MS = 5 // Minimum time to guess for having the max amount of points
+const MIN_TIME_MS = 5000 // Minimum time to guess for having the max amount of points
 const COEF_TIME = 0.8 // this means that player will have 0 points for time if the guess is more than 0.8 * the accorded time
 
 // Game status
@@ -334,7 +334,7 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     const timeScore = this.secretScoreFunction(
       MILLISECONDS_IN_A_ROUND - remainingTimeInMs,
       MAX_SCORE_FOR_TIME,
-      MILLISECONDS_IN_A_ROUND - MIN_TIME_MS,
+      MIN_TIME_MS,
       MILLISECONDS_IN_A_ROUND * COEF_TIME,
     )
 

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -55,7 +55,11 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
   protected coordinatesToGuess: LatLng = new LatLng(0, 0)
   protected satelliteMapCenter: LatLng = new LatLng(0, 0)
   protected satelliteMaxBounds: LatLngBounds = new LatLngBounds(this.coordinatesToGuess, this.coordinatesToGuess)
-  protected materializedBounds: Rectangle = new Rectangle(this.satelliteMaxBounds, {
+  protected materializedSatelliteMapTile: Rectangle = new Rectangle(this.satelliteMaxBounds, {
+    fill: false,
+    color: 'red'
+  })
+  protected materializedGuessingMapTile: Rectangle = new Rectangle(this.satelliteMaxBounds, {
     fill: false,
     color: 'red'
   })
@@ -190,7 +194,8 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
       // each boundary is BOUND_SIZE_IN_METTERS/2 meters apart from coordinates
       this.satelliteMaxBounds = coordinates.toBounds(BOUND_SIZE_IN_METTERS)
       this.coordinatesToGuess = coordinates.clone()
-      this.materializedBounds.setBounds(this.satelliteMaxBounds)
+      this.materializedGuessingMapTile.setBounds(this.satelliteMaxBounds)
+      this.materializedSatelliteMapTile.setBounds(this.satelliteMaxBounds)
 
       // TODO : this is a temporary fix
       // the value assigned to satelliteMaxBounds automatically update the map canvas view in a bounds corner

--- a/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
+++ b/src/app/tile-guessr/tile-guessr-game/tile-guessr-game.component.ts
@@ -72,6 +72,7 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     color: 'red',
     radius: 100
   })
+  protected showGuessingMarker: boolean = false
   private defaultGuessingMapBounds = new LatLngBounds(
     new LatLng(90, 200),
     new LatLng(-90, -200)
@@ -200,13 +201,14 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
     this.description = DEFAULT_PLAYING_DESCRIPTION
     this.currentRoundIndex++;
 
+    // reinitializing maps
+    this.showGuessingMarker = false
+    this.guessingMapFitBounds = this.defaultGuessingMapBounds // TODO : no effects
+
     if (this.currentRoundIndex < this.rounds.length) {
       const currentRound: Round = this.currentRound
       const coordinates = new LatLng(currentRound.latitude, currentRound.longitude)
 
-      // refit guessing map bounds to whole map
-      // TODO : no effects
-      this.guessingMapFitBounds = this.defaultGuessingMapBounds
 
       // display materialized tiles in red again
       this.materializedGuessingMapTile.setStyle(DEFAULT_RECTANGLE_STYLE)
@@ -367,7 +369,10 @@ export class TileGuessrGameComponent implements OnInit, OnDestroy {
   }
 
   protected onGuessingMapClicked(event: { latlng: LatLngExpression; }) {
-    this.guessingMarker.setLatLng(event.latlng)
+    if (this.gameStatus == GameStatus.PLAYING) {
+      this.guessingMarker.setLatLng(event.latlng)
+      this.showGuessingMarker = true
+    }
   }
 
   protected onGuessClicked() {


### PR DESCRIPTION
New features when displaying result :

- The tile to guess is showed in the guessing map
- If the player found the tile, it is shown in green, otherwise in orange
- A dashed line is added to the guessing map between the guessed point and the tile, the map is centered on the line
- A better marker management has been developed
- A score is computed according to time and distance

Bugs resolved :
- For the last round a state of display result is respected before ending the game